### PR TITLE
change any -> ts-ignore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('hast').Root} Root
  * @typedef {import('hast').Element} Element
+ * @typedef {import('hast').Properties} Properties
  *
  * @typedef Options
  * @property {boolean} [overwrite=false]
@@ -22,15 +23,8 @@ export default function rehypeImgLoad(option) {
   return (tree) => {
     visit(tree, "element", (node) => {
       if (node.tagName === "img") {
-        /** @type {any} */
-        // hast's Element.properties is typed as Properties | undefined,
-        // but rehype-parse parses <img>'s node.properties as {}
-        // when <img> doen't have any properties.
-        // And {} is a truthy value,
-        // means if node.tagName === "img", node.properties always exists.
-        // so we need to use 'any' here to avoid typeerror.
-        const properties = node.properties;
-        const isLoadingExists = !!properties.loading;
+        // @ts-ignore <img>.properties is never 'undefined'.
+        const isLoadingExists = node.properties.loading;
         if (setting.overwrite || !isLoadingExists) {
           // if (overwrite is true) then overwrite the loading attribute
           // if (overwrite is false) then only add loading attribute if it doesn't exist


### PR DESCRIPTION
rehype-parse parses `<img>.properties` as `Properties | undefined`, but it is always Properties.